### PR TITLE
Removed  if condition for only two items

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ module.exports = (listOfItems) => {
     return String(listOfItems[0]);
   }
 
-
   // For the non-trivial case of other real number of items
   let index = 0;
   let output = "";

--- a/index.js
+++ b/index.js
@@ -32,10 +32,6 @@ module.exports = (listOfItems) => {
     return String(listOfItems[0]);
   }
 
-  // For two items
-  if (listOfItems.length === 2) {
-    return String(listOfItems[0]) + " and " + String(listOfItems[1]);
-  }
 
   // For the non-trivial case of other real number of items
   let index = 0;


### PR DESCRIPTION
I think it was not necessary to write a condition for only two items as it can be handled by the code for the non-trivial case of other real number of items.
I accidentally made a commit of "Removed if condition for only one item" instead of "Removed if condition for only two items". So, please ignore it.